### PR TITLE
fix: separate state and redirect_uri query params

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -106,9 +106,8 @@ function auth(req: Request): Response {
     if (!jsonState) throw "state not found";
 
     const state = encodeURIComponent(jsonState);
-    const qs = encodeURIComponent(`state=${state}`);
-    const redirectUri = `https://${host}/oidc/tokenize?${qs}`;
-    const keycloakAuthPage = `${KEYCLOAK_AUTH_URI}&redirect_uri=${redirectUri}`;
+    const redirectUri = `https://${host}/oidc/tokenize`;
+    const keycloakAuthPage = `${KEYCLOAK_AUTH_URI}&redirect_uri=${redirectUri}&state=${state}`;
 
     return Response.redirect(keycloakAuthPage, STATUS_CODE.Found);
   } catch (e) {
@@ -145,9 +144,7 @@ async function getAccessToken(
 ): Promise<string> {
   const state = encodeURIComponent(jsonState);
 
-  // Dont encode qs because it will be encoded when inserted into data.
-  const qs = `state=${state}`;
-  const redirectUri = `https://${host}/oidc/tokenize?${qs}`;
+  const redirectUri = `https://${host}/oidc/tokenize`;
 
   const headers = new Headers();
   headers.append("Accept", "application/json");
@@ -156,6 +153,7 @@ async function getAccessToken(
   data.append("grant_type", "authorization_code");
   data.append("redirect_uri", redirectUri);
   data.append("code", code);
+  data.append("state", state);
 
   if (KEYCLOAK_CLIENT_SECRET) {
     headers.append(


### PR DESCRIPTION
As per [\[RFC6749\] Section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1) and [4.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2), `state` is a standalone query parameter and should not be embedded into `redirect_uri`.

[\[RFC6819\] Section 5.2.3.5](https://datatracker.ietf.org/doc/html/rfc6819#section-5.2.3.5) further clarifies that authorization servers (Keycloak) should register and match redirect URIs in full, thus disallowing the inclusion of dynamic query parameters.

There is an [open issue for Keycloak](https://github.com/keycloak/keycloak/issues/16647) requesting stricter enforcement of matching redirect URIs, so the existing implementation may also stop working with future versions of Keycloak.