### PR TITLE
Allow to customize prompt & scope OIDC parameters

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -15,6 +15,7 @@ import {
   KEYCLOAK_ORIGIN,
   KEYCLOAK_ORIGIN_INTERNAL,
   KEYCLOAK_REALM,
+  KEYCLOAK_PROMPT,
   PORT,
 } from "./config.ts";
 import { createContext } from "./context.ts";
@@ -25,7 +26,7 @@ import { createContext } from "./context.ts";
 const KEYCLOAK_AUTH_URI = `${KEYCLOAK_ORIGIN}` +
   `/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth` +
   `?client_id=${KEYCLOAK_CLIENT_ID}&response_mode=${KEYCLOAK_MODE}` +
-  `&response_type=code&scope=openid&prompt=consent`;
+  `&response_type=code&scope=openid&prompt=${KEYCLOAK_PROMPT}`;
 const KEYCLOAK_TOKEN_URI = `${KEYCLOAK_ORIGIN_INTERNAL}` +
   `/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
 const KEYCLOAK_USERINFO_URI = `${KEYCLOAK_ORIGIN_INTERNAL}` +

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -16,6 +16,7 @@ import {
   KEYCLOAK_ORIGIN_INTERNAL,
   KEYCLOAK_REALM,
   KEYCLOAK_PROMPT,
+  KEYCLOAK_SCOPE,
   PORT,
 } from "./config.ts";
 import { createContext } from "./context.ts";
@@ -26,7 +27,7 @@ import { createContext } from "./context.ts";
 const KEYCLOAK_AUTH_URI = `${KEYCLOAK_ORIGIN}` +
   `/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth` +
   `?client_id=${KEYCLOAK_CLIENT_ID}&response_mode=${KEYCLOAK_MODE}` +
-  `&response_type=code&scope=openid&prompt=${KEYCLOAK_PROMPT}`;
+  `&response_type=code&scope=${KEYCLOAK_SCOPE}&prompt=${KEYCLOAK_PROMPT}`;
 const KEYCLOAK_TOKEN_URI = `${KEYCLOAK_ORIGIN_INTERNAL}` +
   `/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
 const KEYCLOAK_USERINFO_URI = `${KEYCLOAK_ORIGIN_INTERNAL}` +

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export const KEYCLOAK_CLIENT_ID = Deno.env.get("KEYCLOAK_CLIENT_ID") || "jitsi";
 export const KEYCLOAK_CLIENT_SECRET = Deno.env.get("KEYCLOAK_CLIENT_SECRET") ||
   "";
 export const KEYCLOAK_MODE = Deno.env.get("KEYCLOAK_MODE") || "query";
+export const KEYCLOAK_PROMPT = Deno.env.get("KEYCLOAK_PROMPT") || "consent";
 
 // jwt
 export const JWT_ALG = Deno.env.get("JWT_ALG") || "HS256";

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,8 @@ export const KEYCLOAK_CLIENT_ID = Deno.env.get("KEYCLOAK_CLIENT_ID") || "jitsi";
 export const KEYCLOAK_CLIENT_SECRET = Deno.env.get("KEYCLOAK_CLIENT_SECRET") ||
   "";
 export const KEYCLOAK_MODE = Deno.env.get("KEYCLOAK_MODE") || "query";
-export const KEYCLOAK_PROMPT = Deno.env.get("KEYCLOAK_PROMPT") || "consent";
+export const KEYCLOAK_PROMPT = Deno.env.get("KEYCLOAK_PROMPT") ?? "consent";
+export const KEYCLOAK_SCOPE = Deno.env.get("KEYCLOAK_SCOPE") || "openid";
 
 // jwt
 export const JWT_ALG = Deno.env.get("JWT_ALG") || "HS256";


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Allow to customize prompt and scope parameters for OIDC client.
Add 2 environement variables : KEYCLOAK_PROMPT & KEYCLOAK_SCOPE
- prompt can be empty and has value 'consent' if env var is missing
- scope is `openid` by default

Modified files: `adapter.ts` and `config.ts`

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
