### PR TITLE
support Electron and mobile clients

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -37,6 +37,13 @@ interface StateType {
   [key: string]: boolean | string;
 }
 
+const enum ClientType {
+  ios,
+  android,
+  electron,
+  browser,
+}
+
 // -----------------------------------------------------------------------------
 // HTTP response for OK
 // -----------------------------------------------------------------------------
@@ -254,6 +261,7 @@ function generateHash(jsonState: string): string {
 
 // -----------------------------------------------------------------------------
 // Create URI of the Jitsi meeting with a token and hashes.
+// Use URI scheme depending on the detected client type.
 // -----------------------------------------------------------------------------
 function getMeetingUri(
   host: string,
@@ -261,12 +269,25 @@ function getMeetingUri(
   room: string,
   jwt: string,
   hash: string,
+  client: ClientType
 ): string {
   path = path || "";
 
+  const clientUriScheme: Record<ClientType, string> = {
+    [ClientType.ios]: "org.jitsi.meet",
+    [ClientType.android]: "intent",
+    [ClientType.electron]: "jitsi-meet",
+    [ClientType.browser]: "https",
+  };
+
   let uri = `${host}/${path}/${room}`;
   uri = uri.replace(/\/+/g, "/");
-  uri = `https://${uri}?jwt=${jwt}#${hash}`;
+  const scheme = clientUriScheme[client];
+  uri = `${scheme}://${uri}?jwt=${jwt}#${hash}`;
+  if (client == ClientType.android)
+  {
+    uri += "#Intent;scheme=org.jitsi.meet;package=org.jitsi.meet;end"
+  }
 
   return uri;
 }
@@ -293,6 +314,21 @@ async function tokenize(req: Request): Promise<Response> {
     const sub = getSub(host, state.tenant);
     const room = state.room;
 
+    // Detect client type
+    let client = ClientType.browser;
+    if (state.ios)
+    {
+      client = ClientType.ios;
+    }
+    else if (state.android)
+    {
+      client = ClientType.android;
+    }
+    else if (state.electron)
+    {
+      client = ClientType.electron;
+    }
+
     // Get the access token from Keycloak using the short-term auth code.
     const accessToken = await getAccessToken(host, code, jsonState);
 
@@ -308,9 +344,33 @@ async function tokenize(req: Request): Promise<Response> {
     // Get URI of the Jitsi meeting.
     // Use unmodified path (state.tenant) which is different than the tenant in
     // JWT context.
-    const meetingPage = getMeetingUri(host, state.tenant, room, jwt, hash);
+    const meetingPage = getMeetingUri(host, state.tenant, room, jwt, hash, client);
 
-    return Response.redirect(meetingPage, STATUS_CODE.Found);
+    if (client == ClientType.browser)
+    {
+      // Normal browser client: redirect to meeting page
+      return Response.redirect(meetingPage, STATUS_CODE.Found);
+    }
+    else
+    {
+      // Show page in web browser that feeds JWT to other clients via auto-refresh
+      const body = `<!DOCTYPE html>
+<html>
+<head>
+<title>Authentication successful</title>
+</head>
+<body>
+<h3>Authentication successful.</h3>
+<p>You can close this tab and go back to your Jitsi client.</p>
+</body>
+</html>`;
+      return new Response(body, {
+        headers: {
+          "refresh": `0; url=${meetingPage}`,
+          "content-type": "text/html",
+        }
+      });
+    }
   } catch (e) {
     console.error(e);
     return unauthorized();


### PR DESCRIPTION
We noticed that when using the jitsi-keycloak-adapter-v2 with the Jitsi Meet Electron client, the Oauth flow happening in the web browser does not return to the Electron client afterwards, but instead joins the meeting in the browser tab.  
This Pull Request tries to improve integration with JME and also mobile clients.

Use the "jitsi-meet" URI scheme in the final redirect if the client is Electron-based. This allows the OAuth flow to return from the web browser back to the Electron client.
Likewise, for mobile clients use the respective URI scheme to return directly to the mobile app after the OAuth flow returns to the adapter.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
